### PR TITLE
Add default parent page setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Welcome to the `Confluence Link` project. The objective of this project is to ma
 -   `Atlassian User Name`: Your Atlassian account's email address
 -   `Atlassian API Token`: Your Atlassian API token. You can generate one from your [Atlassian Account Settings](https://id.atlassian.com/manage-profile/security/api-tokens).
 -   (Optional) `Confluence Default Space`: The space identifier where all you confluence pages will be created
+-   (Optional) `Confluence Default Parent Page`: The parent page ID where newly created Confluence pages will be placed
 
 ![Settings](./images/settings_tab.png)
 

--- a/lib/adaptors/file.ts
+++ b/lib/adaptors/file.ts
@@ -78,6 +78,9 @@ export default class FileAdaptor {
 		const response = await this.client.page.createPage({
 			spaceId: this.spaceId,
 			pageTitle: file.basename,
+			parentId:
+				this.settings.confluenceDefaultParentPageId?.trim() ||
+				undefined,
 		});
 		confluenceUrl = response._links.base + response._links.webui;
 

--- a/lib/confluence/types.ts
+++ b/lib/confluence/types.ts
@@ -3,6 +3,7 @@ export interface ConfluenceLinkSettings {
 	atlassianUsername: string;
 	atlassianApiToken: string;
 	confluenceDefaultSpaceId: string;
+	confluenceDefaultParentPageId: string;
 	followLinks: boolean;
 	uploadTags: boolean;
 	favSpaces: string[];

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -201,6 +201,38 @@ export class ConfluenceLinkSettingsTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
+			.setName("Confluence default parent page")
+			.setDesc("Optional parent page ID for newly created pages")
+			.addText((text) => {
+				let wait: number | null = null;
+
+				text.setPlaceholder("eg: 123456789")
+					.setValue(
+						this.plugin.settings.confluenceDefaultParentPageId || ""
+					)
+					.onChange(async (value) => {
+						const trimmedValue = value.trim();
+
+						if (!trimmedValue || /^\d+$/.test(trimmedValue)) {
+							this.plugin.settings.confluenceDefaultParentPageId =
+								trimmedValue;
+							await this.plugin.saveSettings();
+						} else {
+							if (wait) {
+								window.clearTimeout(wait);
+							}
+
+							wait = window.setTimeout(() => {
+								this.display();
+								new Notice(
+									"Please enter a valid parent page id."
+								);
+							}, 500);
+						}
+					});
+			});
+
+		new Setting(containerEl)
 			.setName("Follow links")
 			.setDesc(
 				"Enable to follow internal links and create those as confluence pages as well"

--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,17 @@ import SpaceSearchModal from "lib/modal";
 import LabelDirector from "lib/directors/label";
 import { isRecentlyModified, wait } from "lib/utils";
 
+const DEFAULT_SETTINGS: ConfluenceLinkSettings = {
+	confluenceDomain: "",
+	atlassianUsername: "",
+	atlassianApiToken: "",
+	confluenceDefaultSpaceId: "",
+	confluenceDefaultParentPageId: "",
+	followLinks: false,
+	uploadTags: false,
+	favSpaces: [],
+};
+
 export default class ConfluenceLink extends Plugin {
 	settings: ConfluenceLinkSettings;
 
@@ -103,8 +114,12 @@ export default class ConfluenceLink extends Plugin {
 	}
 
 	async uploadFile(filePath: string, spaceId: string | null) {
-		const { atlassianUsername, atlassianApiToken, confluenceDomain } =
-			this.settings;
+		const {
+			atlassianUsername,
+			atlassianApiToken,
+			confluenceDomain,
+			confluenceDefaultParentPageId,
+		} = this.settings;
 
 		if (!atlassianApiToken || !atlassianUsername || !confluenceDomain) {
 			new Notice(
@@ -152,6 +167,7 @@ export default class ConfluenceLink extends Plugin {
 			response = await client.page.createPage({
 				spaceId: spaceId as string,
 				pageTitle: file.basename,
+				parentId: confluenceDefaultParentPageId?.trim() || undefined,
 			});
 
 			propAdaptor.addProperties({
@@ -183,7 +199,11 @@ export default class ConfluenceLink extends Plugin {
 	async onunload() {}
 
 	async loadSettings() {
-		this.settings = Object.assign({ favSpaces: [] }, await this.loadData());
+		this.settings = Object.assign(
+			{},
+			DEFAULT_SETTINGS,
+			await this.loadData()
+		);
 	}
 
 	async saveSettings() {


### PR DESCRIPTION
Closes #48.\n\n## Summary\n- add an optional default parent page ID setting\n- pass that parent ID when creating a new uploaded page\n- apply the same parent ID to linked pages created while following internal links\n- document the new setting in the README\n\n## Verification\n- npm run build\n- git diff --check\n\nNote: npm run lint currently fails on pre-existing repo-wide lint errors unrelated to this change.